### PR TITLE
Fix broken shared 32-/64-bit semaphores on recent glibc versions.

### DIFF
--- a/rdwrops.h
+++ b/rdwrops.h
@@ -32,16 +32,11 @@ struct RingBuffer
 
 struct ShmControl
 {
-    // 32 and 64-bit binaries align semaphores differently.
-    // Let's make sure there's plenty of room for either one.
-    union {
-        sem_t runServer;
-        char alignServerSem[32];
-    };
-    union {
-        sem_t runClient;
-        char alignClientSem[32];
-    };
+    // Pipe will be used by both 64- and 32- bit, so store as the former.
+    int64_t runServerRead;
+    int64_t runServerWrite;
+    int64_t runClientRead;
+    int64_t runClientWrite;
     RingBuffer ringBuffer;
 };
 


### PR DESCRIPTION
Recent versions of glibc have changed the memory layout of semaphores
on 64-bit, which means that 32- and 64-bit semaphores are
fundamentally incompatible and cannot be shared anymore. The symptom
is that the plugin hangs on communicating with the child process, and
eventually times out.

However, my previous assumption in 2cefab1f9f22, that pipes are not
realtime safe on Linux, was incorrect. They are used by Jack all the
time. So the problem is fixed by switching to pipes for process
synchronization. Shared memory is still used for the data though, as
well as to store the pipe descriptors.

Another nice side effect of this fix is that we now get notified again
when the child process dies or otherwise breaks the connection.

Signed-off-by: Kristian Amlie <kristian@amlie.name>